### PR TITLE
Bump cookiecutter template to 5446da

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "57e9b752fed460f5542bda226467210d0135f4fb",
+  "commit": "5446dae8486bd2412e75f97790c6bd800fa26a34",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -8,7 +8,7 @@
       "short_summary": "Create artificial data for the MEx project.",
       "long_summary": "Create artificial extracted items, transform them into merged items and write the results into a configured sink.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "57e9b752fed460f5542bda226467210d0135f4fb"
+      "_commit": "5446dae8486bd2412e75f97790c6bd800fa26a34"
     }
   },
   "directory": null

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,20 +1,20 @@
-# PR Context
+### PR Context
 <!-- Additional info for the reviewer -->
 
-# Added
+### Added
 <!-- New features and interfaces -->
 
-# Changes
+### Changes
 <!-- Changes in existing functionality -->
 
-# Deprecated
+### Deprecated
 <!-- Soon-to-be removed features -->
 
-# Removed
+### Removed
 <!-- Definitely removed features -->
 
-# Fixed
+### Fixed
 <!-- Fixed bugs -->
 
-# Security
+### Security
 <!-- Fixed vulnerabilities -->

--- a/.github/workflows/renovatebot.yml
+++ b/.github/workflows/renovatebot.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run renovatebot
-        uses: renovatebot/github-action@v41.0.10
+        uses: renovatebot/github-action@v41.0.11
         env:
           RENOVATE_GIT_PRIVATE_KEY: ${{ secrets.GPG_SIGNING_KEY }}
           RENOVATE_REPOSITORIES: "robert-koch-institut/mex-artificial"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ available to external researchers as well as the interested (professional) publi
 find research data from the RKI.
 
 For further details, please consult our
-[project page](https://www.rki.de/DE/Content/Forsch/MEx/MEx_node.html).
+[project page](https://www.rki.de/DE/Aktuelles/Publikationen/Forschungsdaten/MEx/metadata-exchange-plattform-mex-node.html).
 
 [^1]: FAIR is referencing the so-called
 [FAIR data principles](https://www.go-fair.org/fair-principles/) – guidelines to make

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cruft==2.16.0
 mex-release==0.3.0
-pdm==2.22.2
+pdm==2.22.3
 pre-commit==4.1.0


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/5446da

# Conflicts

```diff a/requirements.txt b/requirements.txt	(rejected hunks)
@@ -1,4 +1,4 @@
 cruft==2.16.0
 mex-release==0.3.0
-pdm==2.22.1
-pre-commit==4.0.1
+pdm==2.22.3
+pre-commit==4.1.0
```

```diff a/.github/workflows/renovatebot.yml b/.github/workflows/renovatebot.yml	(rejected hunks)
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run renovatebot
-        uses: renovatebot/github-action@v41.0.8
+        uses: renovatebot/github-action@v41.0.11
         env:
           RENOVATE_GIT_PRIVATE_KEY: ${{ secrets.GPG_SIGNING_KEY }}
           RENOVATE_REPOSITORIES: "robert-koch-institut/mex-artificial"
```

```diff a/Dockerfile b/Dockerfile	(rejected hunks)
@@ -12,7 +12,7 @@ ENV PYTHONUNBUFFERED=1
 ENV PYTHONOPTIMIZE=1
 
 ENV PIP_DISABLE_PIP_VERSION_CHECK=on
-ENV PIP_NO_INPUT: on
+ENV PIP_NO_INPUT=on
 ENV PIP_PREFER_BINARY=on
 ENV PIP_PROGRESS_BAR=off
 
```
