### PR TITLE
add pypi publishing to github release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,6 +130,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: release
+    environment:
+      name: pypi
+      url: https://pypi.org/p/mex-release
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -164,3 +169,6 @@ jobs:
           for filename in dist/*; do
             gh release upload ${{ needs.release.outputs.tag }} ${filename};
           done
+
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- running github release action publishes to pypi
+
 ### Changes
 
 ### Deprecated


### PR DESCRIPTION
### Added
<!-- New features and interfaces -->

- running github release action publishes to pypi