### PR TITLE
Bump cookiecutter template to 1d816d

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "26afa85ef969fa8385019c932f32d6b7b452b142",
+  "commit": "1d816db77df20388022165cab12f45821d0b9f6d",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -8,7 +8,7 @@
       "short_summary": "Create artificial data for the MEx project.",
       "long_summary": "Create artificial extracted items, transform them into merged items and write the results into a configured sink.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "26afa85ef969fa8385019c932f32d6b7b452b142"
+      "_commit": "1d816db77df20388022165cab12f45821d0b9f6d"
     }
   },
   "directory": null

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- updated template to https://github.com/robert-koch-institut/mex-template/commit/1d816d
+
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/26afa8
 
 ### Deprecated

--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,7 @@
     "lockFileMaintenance": {
         "enabled": true,
         "schedule": [
-            "before 4am on monday"
+            "on monday"
         ]
     },
     "packageRules": [
@@ -38,7 +38,30 @@
             "pinDigests": true
         },
         {
-            "description": "Immediately apply updates of mex packages",
+            "description": "Group all GitHub Actions updates into a single PR",
+            "groupName": "github-actions",
+            "matchManagers": [
+                "github-actions"
+            ]
+        },
+        {
+            "description": "Group all non-major Python updates into a single PR",
+            "groupName": "python non-major",
+            "matchCurrentVersion": "!/^0/",
+            "matchManagers": [
+                "pep621",
+                "pip_requirements"
+            ],
+            "matchUpdateTypes": [
+                "minor",
+                "patch",
+                "pin",
+                "digest"
+            ]
+        },
+        {
+            "description": "Immediately apply updates of mex packages in dedicated PR",
+            "groupName": null,
             "matchPackageNames": [
                 "mex-*"
             ],
@@ -46,6 +69,9 @@
         }
     ],
     "prFooter": "",
+    "pre-commit": {
+        "enabled": true
+    },
     "vulnerabilityAlerts": {
         "enabled": true
     }


### PR DESCRIPTION
### Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/1d816d
