### PR TITLE
Bump cookiecutter template to 52887e

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "1d816db77df20388022165cab12f45821d0b9f6d",
+  "commit": "52887e07dbc2501edea124e2a27a4f472f970d7e",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -8,7 +8,7 @@
       "short_summary": "Create artificial data for the MEx project.",
       "long_summary": "Create artificial extracted items, transform them into merged items and write the results into a configured sink.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "1d816db77df20388022165cab12f45821d0b9f6d"
+      "_commit": "52887e07dbc2501edea124e2a27a4f472f970d7e"
     }
   },
   "directory": null

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- updated template to https://github.com/robert-koch-institut/mex-template/commit/52887e
+
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/1d816d
 
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/26afa8


### PR DESCRIPTION
### Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/52887e
